### PR TITLE
Detect img changes by user. Enhanced timer handling.

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,11 +47,8 @@ const functionFlexIntervals = (interface) => {
     () => {
       counter = 1;
       // trigger next change
-      const now = new Date().getTime();
-      if ((nextChangeTime - now) > minChangeTime) {
-        nextChangeTime = now + minChangeTime;
-        setChangeTimer(minChangeTime);
-      }
+      nextChangeTime = new Date().getTime() + minChangeTime;
+      setChangeTimer(minChangeTime);
     });
 
   // additional handling for 'paused' event.

--- a/index.js
+++ b/index.js
@@ -6,20 +6,55 @@
 const functionFlexIntervals = (interface) => {
 
   var config;
+  // show the image for at least two seconds and
+  // calculate the real value as soon as the config is available
+  var minChangeTime = 2000;
   var counter = 1;
   var isPaused = false;
   var changeTimeout = 0;
+  var nextChangeTime = 0;
+
+  /**
+   * Triggers the next image change if not paused
+   * @param {number} additionalChange millisecond
+   */
+  const setChangeTimer = (additionalChange) => {
+    clearTimeout(changeTimeout);
+    if (!isPaused ) {
+      // to enable logging execute: `~/TeleFrame/tools/addon_control flexInterval config logNextChangeInterval true`
+      if (interface.config.logNextChangeInterval) {
+        interface.logger.info("additional change in: " + additionalChange);
+      }
+      changeTimeout = setTimeout(() => {
+        // show next image only if there was no user interaction
+        if (!isPaused && new Date().getTime() >= nextChangeTime) {
+          // use the half of the configured fadeTime
+          interface.sendEvent('next', config.fadeTime / 2);
+        }
+      }, additionalChange);
+    }
+  };
+
 
   interface.registerListener('teleFrame-ready', teleFrameObjects => {
     config = teleFrameObjects.config;
+    minChangeTime = Math.max(2000, Math.round(config.interval/config.imageCount));
   });
   //interface.registerListener('newImage', (sender, type) => counter = 1);
 
   interface.registerListener(['images-loaded', 'imageDeleted', 'paused', 'muted',
     'recordStopped', 'unstarImage', 'starImage'],
-    () => counter = 1);
+    () => {
+      counter = 1;
+      // trigger next change
+      const now = new Date().getTime();
+      if ((nextChangeTime - now) > minChangeTime) {
+        nextChangeTime = now + minChangeTime;
+        setChangeTimer(minChangeTime);
+      }
+    });
 
-  // additional handling for Äpaused' event.
+  // additional handling for 'paused' event.
   // if paused call clearTimeout
   interface.registerListener('paused', (status) => {
     isPaused = status;
@@ -29,11 +64,16 @@ const functionFlexIntervals = (interface) => {
   });
 
   interface.registerListener('changedActiveImage', index => {
+    clearTimeout(changeTimeout);
+    // detect manual image change
+    if (new Date().getTime() < nextChangeTime) {
+      counter = 1;
+    }
+    const additionalChange = Math.max(minChangeTime, Math.round(config.interval*counter/config.imageCount));
+    nextChangeTime = new Date().getTime() + additionalChange;
     // introduce an additional picture change:
     if (!isPaused && counter < config.imageCount) {
-      var additionalChange = Math.round(config.interval*counter/config.imageCount);
-      interface.logger.info("additional change in: " + additionalChange);
-      changeTimeout = setTimeout(() => { interface.sendEvent('next'); }, additionalChange);
+      setChangeTimer(additionalChange);
       counter += 1;
     };
   });

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const functionFlexIntervals = (interface) => {
   var config;
   // show the image for at least two seconds and
   // calculate the real value as soon as the config is available
-  var minChangeTime = 2000;
+  var minChangeTime = 3000;
   var counter = 1;
   var isPaused = false;
   var changeTimeout = 0;
@@ -38,7 +38,7 @@ const functionFlexIntervals = (interface) => {
 
   interface.registerListener('teleFrame-ready', teleFrameObjects => {
     config = teleFrameObjects.config;
-    minChangeTime = Math.max(2000, Math.round(config.interval/config.imageCount));
+    minChangeTime = Math.max(minChangeTime, Math.round(config.interval/config.imageCount));
   });
   //interface.registerListener('newImage', (sender, type) => counter = 1);
 


### PR DESCRIPTION
Unfortunately the addon documentation for the events previous/next forgot the argument fadeIntervall. But this argument is available.

This PR uses fadeTime to change the next picture.
It is recognized whether the user has manually changed an image. For other interactions, the smallest possible switching time is used and the timer is initialized. The timer is reset on interactions.

flexintervals is really a great addon idea I like it 👍 